### PR TITLE
feat: add support for the Account category

### DIFF
--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,4 +1,4 @@
-use crate::{client::Licheszter, error::Result, models::user::{Email, KidMode, User}};
+use crate::{client::Licheszter, error::Result, models::{common::OkResponse, user::{Email, KidMode, User}}};
 
 impl Licheszter {
     /// Public information about the logged in user.
@@ -26,5 +26,14 @@ impl Licheszter {
         let builder = self.client.get(url);
 
         self.to_model::<KidMode>(builder).await
+    }
+
+    /// Set the kid mode status of the logged in user.
+    pub async fn account_kid_mode_set(&self, kid: bool) -> Result<OkResponse> {
+        let mut url = self.base_url();
+        url.set_path("api/account/kid");
+        let builder = self.client.post(url).query(&[("v", kid)]);
+
+        self.to_model::<OkResponse>(builder).await
     }
 }

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,0 +1,12 @@
+use crate::{client::Licheszter, error::Result, models::user::User};
+
+impl Licheszter {
+    /// Public information about the logged in user.
+    pub async fn account_profile(&self) -> Result<User> {
+        let mut url = self.base_url();
+        url.set_path("api/account");
+        let builder = self.client.get(url);
+
+        self.to_model::<User>(builder).await
+    }
+}

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,4 +1,11 @@
-use crate::{client::Licheszter, error::Result, models::{common::OkResponse, user::{Email, KidMode, Preferences, User}}};
+use crate::{
+    client::Licheszter,
+    error::Result,
+    models::{
+        common::OkResponse,
+        user::{Email, KidMode, Preferences, Timeline, User},
+    },
+};
 
 impl Licheszter {
     /// Public information about the logged in user.
@@ -44,5 +51,14 @@ impl Licheszter {
         let builder = self.client.post(url).query(&[("v", kid)]);
 
         self.to_model::<OkResponse>(builder).await
+    }
+
+    /// Get the timeline events of the logged in user.
+    pub async fn account_timeline(&self, since: Option<u64>, nb: Option<u8>) -> Result<Timeline> {
+        let mut url = self.base_url();
+        url.set_path("api/timeline");
+        let builder = self.client.get(url).query(&(("since", since), ("nb", nb)));
+
+        self.to_model::<Timeline>(builder).await
     }
 }

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,4 +1,4 @@
-use crate::{client::Licheszter, error::Result, models::user::User};
+use crate::{client::Licheszter, error::Result, models::user::{Email, User}};
 
 impl Licheszter {
     /// Public information about the logged in user.
@@ -8,5 +8,14 @@ impl Licheszter {
         let builder = self.client.get(url);
 
         self.to_model::<User>(builder).await
+    }
+
+    /// Read the email address of the logged in user.
+    pub async fn account_email(&self) -> Result<Email> {
+        let mut url = self.base_url();
+        url.set_path("api/account/email");
+        let builder = self.client.get(url);
+
+        self.to_model::<Email>(builder).await
     }
 }

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,4 +1,4 @@
-use crate::{client::Licheszter, error::Result, models::{common::OkResponse, user::{Email, KidMode, User}}};
+use crate::{client::Licheszter, error::Result, models::{common::OkResponse, user::{Email, KidMode, Preferences, User}}};
 
 impl Licheszter {
     /// Public information about the logged in user.
@@ -17,6 +17,15 @@ impl Licheszter {
         let builder = self.client.get(url);
 
         self.to_model::<Email>(builder).await
+    }
+
+    /// Read the preferences of the logged in user.
+    pub async fn account_preferences(&self) -> Result<Preferences> {
+        let mut url = self.base_url();
+        url.set_path("api/account/preferences");
+        let builder = self.client.get(url);
+
+        self.to_model::<Preferences>(builder).await
     }
 
     /// Read the kid mode status of the logged in user.

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,4 +1,4 @@
-use crate::{client::Licheszter, error::Result, models::user::{Email, User}};
+use crate::{client::Licheszter, error::Result, models::user::{Email, KidMode, User}};
 
 impl Licheszter {
     /// Public information about the logged in user.
@@ -17,5 +17,14 @@ impl Licheszter {
         let builder = self.client.get(url);
 
         self.to_model::<Email>(builder).await
+    }
+
+    /// Read the kid mode status of the logged in user.
+    pub async fn account_kid_mode(&self) -> Result<KidMode> {
+        let mut url = self.base_url();
+        url.set_path("api/account/kid");
+        let builder = self.client.get(url);
+
+        self.to_model::<KidMode>(builder).await
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod challenges;
 pub mod misc;
 pub mod relations;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -253,3 +253,9 @@ pub struct Streamer {
 pub struct StreamerChannel {
     pub channel: String,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+pub struct Email {
+    pub email: String,
+}

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -259,3 +259,9 @@ pub struct StreamerChannel {
 pub struct Email {
     pub email: String,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+pub struct KidMode {
+    pub kid: bool,
+}

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -45,6 +45,57 @@ pub struct User {
     pub follows_you: bool,
 }
 
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+#[serde(rename_all = "camelCase")]
+pub struct UserPreferences {
+    pub dark: bool,
+    pub transp: bool,
+    pub bg_img: Option<String>,
+    pub is_3d: bool,
+    pub theme: String,
+    pub piece_set: String,
+    pub theme_3d: String,
+    pub piece_set_3d: String,
+    pub sound_set: String,
+    pub blindfold: Option<u8>,
+    pub auto_queen: u8,
+    pub auto_threefold: u8,
+    pub takeback: u8,
+    pub moretime: u8,
+    pub clock_tenths: u8,
+    pub clock_bar: bool,
+    pub clock_sound: bool,
+    pub premove: bool,
+    pub animation: u8,
+    pub piece_notation: u8,
+    pub captured: bool,
+    pub follow: bool,
+    pub highlight: bool,
+    pub destination: bool,
+    pub coords: u8,
+    pub replay: u8,
+    pub challenge: u8,
+    pub message: u8,
+    pub coord_color: Option<u8>,
+    pub submit_move: u8,
+    pub confirm_resign: u8,
+    pub insight_share: u8,
+    pub keyboard_move: u8,
+    pub zen: u8,
+    pub ratings: u8,
+    pub move_event: u8,
+    pub rook_castle: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+pub struct Preferences {
+    pub prefs: UserPreferences,
+    pub language: String,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PerfType {

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -20,7 +20,7 @@ pub struct User {
     pub disabled: bool,
     #[serde(default)]
     pub tos_violation: bool,
-    pub profile: Option<BotProfile>,
+    pub profile: Option<Profile>,
     #[serde_as(as = "TimestampMilliSeconds")]
     pub seen_at: PrimitiveDateTime,
     #[serde(default)]
@@ -163,7 +163,7 @@ pub struct BotUser {
     pub disabled: bool,
     #[serde(default)]
     pub tos_violation: bool,
-    pub profile: BotProfile,
+    pub profile: Profile,
     #[serde_as(as = "TimestampMilliSeconds")]
     pub seen_at: PrimitiveDateTime,
     #[serde(default)]
@@ -201,13 +201,11 @@ pub struct BotPerfs {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
 #[serde(rename_all = "camelCase")]
-pub struct BotProfile {
-    pub country: Option<String>,
+pub struct Profile {
     pub location: Option<String>,
     pub bio: Option<String>,
     pub flag: Option<String>,
-    pub first_name: Option<String>,
-    pub last_name: Option<String>,
+    pub real_name: Option<String>,
     pub links: Option<String>,
     pub fide_rating: Option<u16>,
     pub uscf_rating: Option<u16>,

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -93,3 +93,28 @@ async fn account_kid_mode() {
         result.unwrap()
     );
 }
+
+#[tokio::test]
+async fn account_kid_mode_set() {
+    // Run some test cases
+    let result = LI.account_kid_mode_set(false).await;
+    assert!(
+        result.is_ok(),
+        "Failed to set account kid mode: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = BOT0.account_kid_mode_set(false).await;
+    assert!(
+        result.is_ok(),
+        "Failed to set account kid mode: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().account_kid_mode_set(true).await;
+    assert!(
+        result.is_err(),
+        "Setting account kid mode did not fail: {:?}",
+        result.unwrap()
+    );
+}

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -68,3 +68,28 @@ async fn account_email() {
         result.unwrap()
     );
 }
+
+#[tokio::test]
+async fn account_kid_mode() {
+    // Run some test cases
+    let result = LI.account_kid_mode().await;
+    assert!(
+        result.is_ok(),
+        "Failed to check account kid mode: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = BOT0.account_kid_mode().await;
+    assert!(
+        result.is_ok(),
+        "Failed to check account kid mode: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().account_kid_mode().await;
+    assert!(
+        result.is_err(),
+        "Checking account kid mode did not fail: {:?}",
+        result.unwrap()
+    );
+}

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -1,0 +1,45 @@
+use std::{error::Error, sync::LazyLock};
+
+use licheszter::client::Licheszter;
+
+// Connect to test accounts
+static LI: LazyLock<Licheszter> = LazyLock::new(|| {
+    Licheszter::builder()
+        .with_base_url("http://localhost:8080")
+        .unwrap()
+        .with_authentication("lip_li")
+        .build()
+});
+
+static BOT0: LazyLock<Licheszter> = LazyLock::new(|| {
+    Licheszter::builder()
+        .with_base_url("http://localhost:8080")
+        .unwrap()
+        .with_authentication("lip_bot0")
+        .build()
+});
+
+#[tokio::test]
+async fn account_profile() {
+    // Run some test cases
+    let result = LI.account_profile().await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch profile information: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = BOT0.account_profile().await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch profile information: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().account_profile().await;
+    assert!(
+        result.is_err(),
+        "Fetching profile information did not fail: {:?}",
+        result.unwrap()
+    );
+}

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -143,3 +143,35 @@ async fn account_kid_mode_set() {
         result.unwrap()
     );
 }
+
+#[tokio::test]
+async fn account_timeline() {
+    // Run some test cases
+    let result = LI.account_timeline(None, None).await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account timeline: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = LI.account_timeline(Some(1704060000000), Some(10)).await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account timeline: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = BOT0.account_timeline(Some(1704060000000), Some(30)).await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account timeline: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().account_timeline(None, None).await;
+    assert!(
+        result.is_err(),
+        "Fetching account timeline did not fail: {:?}",
+        result.unwrap()
+    );
+}

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -43,3 +43,28 @@ async fn account_profile() {
         result.unwrap()
     );
 }
+
+#[tokio::test]
+async fn account_email() {
+    // Run some test cases
+    let result = LI.account_email().await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account email: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = BOT0.account_email().await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account email: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().account_email().await;
+    assert!(
+        result.is_err(),
+        "Fetching account email did not fail: {:?}",
+        result.unwrap()
+    );
+}

--- a/tests/account.rs
+++ b/tests/account.rs
@@ -70,6 +70,31 @@ async fn account_email() {
 }
 
 #[tokio::test]
+async fn account_preferences() {
+    // Run some test cases
+    let result = LI.account_preferences().await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account preferences: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = BOT0.account_preferences().await;
+    assert!(
+        result.is_ok(),
+        "Failed to fetch account preferences: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().account_preferences().await;
+    assert!(
+        result.is_err(),
+        "Fetching account preferences did not fail: {:?}",
+        result.unwrap()
+    );
+}
+
+#[tokio::test]
 async fn account_kid_mode() {
     // Run some test cases
     let result = LI.account_kid_mode().await;


### PR DESCRIPTION
Adds support for all endpoints in the Account category.

Closes #8.