### PR TITLE
feat: add support for the Messaging category

### DIFF
--- a/src/api/messaging.rs
+++ b/src/api/messaging.rs
@@ -1,0 +1,13 @@
+use crate::{client::Licheszter, error::Result, models::common::OkResponse};
+
+impl Licheszter {
+    pub async fn message_private_send(&self, username: &str, text: &str) -> Result<()> {
+        let mut url = self.base_url();
+        let path = format!("/inbox/{username}");
+        url.set_path(&path);
+        let builder = self.client.post(url).form(&[("text", text)]);
+
+        self.to_model::<OkResponse>(builder).await?;
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod challenges;
+pub mod messaging;
 pub mod misc;
 pub mod relations;
 

--- a/tests/messaging.rs
+++ b/tests/messaging.rs
@@ -1,0 +1,52 @@
+use std::{error::Error, sync::LazyLock};
+
+use licheszter::client::Licheszter;
+
+// Connect to test accounts
+static LI: LazyLock<Licheszter> = LazyLock::new(|| {
+    Licheszter::builder()
+        .with_base_url("http://localhost:8080")
+        .unwrap()
+        .with_authentication("lip_li")
+        .build()
+});
+
+static ADRIANA: LazyLock<Licheszter> = LazyLock::new(|| {
+    Licheszter::builder()
+        .with_base_url("http://localhost:8080")
+        .unwrap()
+        .with_authentication("lip_adriana")
+        .build()
+});
+
+#[tokio::test]
+async fn message_private_send() {
+    // Run some test cases
+    let result = LI.message_private_send("Adriana", "What's up bro?").await;
+    assert!(
+        result.is_ok(),
+        "Failed to send private message: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = ADRIANA.message_private_send("Li", "I'm great hbu?").await;
+    assert!(
+        result.is_ok(),
+        "Failed to send private message: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = LI.message_private_send("NoSuchUser", "Let's try our luck").await;
+    assert!(
+        result.is_err(),
+        "Sending private message did not fail: {:?}",
+        result.unwrap()
+    );
+
+    let result = LI.message_private_send("Bot0", "Let's try our luck").await;
+    assert!(
+        result.is_err(),
+        "Sending private message did not fail: {:?}",
+        result.unwrap()
+    );
+}


### PR DESCRIPTION
Adds support for the only endpoint in the Messaging category.

Closes #20.