### PR TITLE
feat: add support for the Simuls category

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,6 +4,7 @@ pub mod messaging;
 pub mod misc;
 pub mod puzzles;
 pub mod relations;
+pub mod simuls;
 
 #[cfg(feature = "openings")]
 pub mod openings;

--- a/src/api/simuls.rs
+++ b/src/api/simuls.rs
@@ -1,0 +1,11 @@
+use crate::{client::Licheszter, error::Result, models::simul::Simuls};
+
+impl Licheszter {
+    pub async fn simuls_current(&self) -> Result<Simuls> {
+        let mut url = self.base_url();
+        url.set_path("api/simul");
+        let builder = self.client.get(url);
+
+        self.into::<Simuls>(builder).await
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod chat;
 pub mod common;
 pub mod game;
 pub mod puzzle;
+pub mod simul;
 pub mod user;
 
 #[cfg(feature = "openings")]

--- a/src/models/simul.rs
+++ b/src/models/simul.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, skip_serializing_none, TimestampMilliSeconds};
+use time::PrimitiveDateTime;
+
+use super::{game::Perf, user::Title};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+pub struct Simuls {
+    pub pending: Vec<Simul>,
+    pub created: Vec<Simul>,
+    pub started: Vec<Simul>,
+    pub finished: Vec<Simul>,
+}
+
+#[skip_serializing_none]
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+#[serde(rename_all = "camelCase")]
+pub struct Simul {
+    pub id: String,
+    pub name: String,
+    pub full_name: String,
+    pub host: SimulHost,
+    #[serde(default)]
+    pub is_created: bool,
+    #[serde(default)]
+    pub is_finished: bool,
+    #[serde(default)]
+    pub is_running: bool,
+    #[serde_as(as = "Option<TimestampMilliSeconds>")]
+    pub estimated_start_at: Option<PrimitiveDateTime>,
+    #[serde_as(as = "Option<TimestampMilliSeconds>")]
+    pub started_at: Option<PrimitiveDateTime>,
+    #[serde_as(as = "Option<TimestampMilliSeconds>")]
+    pub finished_at: Option<PrimitiveDateTime>,
+    pub nb_applicants: u16,
+    pub nb_pairings: u16,
+    pub text: String,
+    pub variants: Vec<Perf>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+#[serde(rename_all = "camelCase")]
+pub struct SimulHost {
+    pub id: String,
+    pub name: String,
+    pub rating: Option<u16>,
+    pub title: Option<Title>,
+    #[serde(default)]
+    pub online: bool,
+    #[serde(default)]
+    pub provisional: bool,
+    pub flair: Option<String>,
+}

--- a/tests/simuls.rs
+++ b/tests/simuls.rs
@@ -1,0 +1,38 @@
+use std::{error::Error, sync::LazyLock};
+
+use licheszter::client::Licheszter;
+
+// Connect to test accounts
+static LI: LazyLock<Licheszter> = LazyLock::new(|| {
+    Licheszter::builder()
+        .with_base_url("http://localhost:8080")
+        .unwrap()
+        .with_authentication("lip_li")
+        .build()
+});
+
+static ADRIANA: LazyLock<Licheszter> = LazyLock::new(|| {
+    Licheszter::builder()
+        .with_base_url("http://localhost:8080")
+        .unwrap()
+        .with_authentication("lip_adriana")
+        .build()
+});
+
+#[tokio::test]
+async fn simuls_current() {
+    // Run some test cases
+    let result = LI.simuls_current().await;
+    assert!(
+        result.is_ok(),
+        "Failed to get current simuls: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = ADRIANA.simuls_current().await;
+    assert!(
+        result.is_ok(),
+        "Failed to get current simuls: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+}


### PR DESCRIPTION
Adds support for the only endpoint in the Simuls category.

Closes #18.