### PR TITLE
feat: update the Puzzles category

### DIFF
--- a/src/api/puzzles.rs
+++ b/src/api/puzzles.rs
@@ -2,6 +2,7 @@ use futures_util::Stream;
 
 use crate::{
     client::Licheszter,
+    config::puzzles::PuzzleDifficulty,
     error::Result,
     models::puzzle::{Puzzle, PuzzleActivity, PuzzleDashboard, PuzzleRace, PuzzleStormDashboard},
 };
@@ -22,6 +23,23 @@ impl Licheszter {
         let path = format!("api/puzzle/{id}");
         url.set_path(&path);
         let builder = self.client.get(url);
+
+        self.into::<Puzzle>(builder).await
+    }
+
+    /// Get a random puzzle.
+    /// If authenticated, only returns puzzles the user has never seen before.
+    pub async fn puzzle_next(
+        &self,
+        angle: Option<&str>,
+        difficulty: Option<PuzzleDifficulty>,
+    ) -> Result<Puzzle> {
+        let mut url = self.base_url();
+        url.set_path("api/puzzle/next");
+        let builder = self
+            .client
+            .get(url)
+            .query(&(("angle", angle), ("difficulty", difficulty)));
 
         self.into::<Puzzle>(builder).await
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod challenges;
+pub mod puzzles;
 
 #[cfg(feature = "board")]
 pub mod board;

--- a/src/config/puzzles.rs
+++ b/src/config/puzzles.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PuzzleDifficulty {
+    Easiest,
+    Easier,
+    Normal,
+    Harder,
+    Hardest,
+}

--- a/src/models/puzzle.rs
+++ b/src/models/puzzle.rs
@@ -14,6 +14,7 @@ use super::{
 pub struct Puzzle {
     pub game: PuzzleGame,
     pub puzzle: PuzzleDetails,
+    pub user: Option<PuzzleAuthUser>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -58,6 +59,13 @@ pub struct PuzzleUser {
     pub patron: bool,
     pub rating: u16,
     pub title: Option<Title>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde-strict", serde(deny_unknown_fields))]
+pub struct PuzzleAuthUser {
+    pub id: String,
+    pub rating: u16,
 }
 
 #[serde_as]

--- a/tests/puzzles.rs
+++ b/tests/puzzles.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, sync::LazyLock};
 
 use futures_util::StreamExt;
-use licheszter::client::Licheszter;
+use licheszter::{client::Licheszter, config::puzzles::PuzzleDifficulty};
 
 // Connect to test accounts
 static LI: LazyLock<Licheszter> = LazyLock::new(|| {
@@ -47,6 +47,47 @@ async fn puzzle_show() {
     assert!(
         result.is_ok(),
         "Failed to get puzzle: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn puzzle_next() {
+    // Run some test cases
+    let result = LI.puzzle_next(None, None).await;
+    assert!(
+        result.is_ok(),
+        "Failed to get next puzzle: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = LI
+        .puzzle_next(Some("rookEndgame"), Some(PuzzleDifficulty::Normal))
+        .await;
+    assert!(
+        result.is_ok(),
+        "Failed to get next puzzle: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = LI.puzzle_next(Some("mix"), None).await;
+    assert!(
+        result.is_ok(),
+        "Failed to get next puzzle: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = LI.puzzle_next(None, Some(PuzzleDifficulty::Hardest)).await;
+    assert!(
+        result.is_ok(),
+        "Failed to get next puzzle: {:?}",
+        result.unwrap_err().source().unwrap()
+    );
+
+    let result = Licheszter::new().puzzle_next(None, None).await;
+    assert!(
+        result.is_ok(),
+        "Failed to get next puzzle: {:?}",
         result.unwrap_err().source().unwrap()
     );
 }


### PR DESCRIPTION
Adds support for 1 new endpoint in the Puzzles category.

- [Get a new puzzle](https://lichess.org/api#tag/Puzzles/operation/apiPuzzleNext)

Updates #13.