### PR TITLE
feat: upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/licheszter"
 keywords = ["lichess", "bot", "api", "wrapper", "chess"]
 categories = ["api-bindings", "asynchronous"]
 readme = "README.md"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "licheszter"
@@ -19,19 +19,19 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = "1.42.0"
+tokio = "1.45.1"
 tokio-stream = { version = "0.1.17", default-features = false, features = ["io-util"] }
-tokio-util = "0.7.13"
-reqwest = { version = "0.12.9", default-features = false, features = ["stream", "rustls-tls"] }
-time = { version = "0.3.37", features = ["parsing", "serde"]}
-serde = { version = "1.0.216", features = ["derive"] }
-serde_json = "1.0.133"
-serde_with = { version = "3.11.0", features = ["time_0_3"] }
+tokio-util = "0.7.15"
+reqwest = { version = "0.12.20", default-features = false, features = ["stream", "rustls-tls"] }
+time = { version = "0.3.41", features = ["parsing", "serde"]}
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+serde_with = { version = "3.13.0", features = ["time_0_3"] }
 futures-util = { version = "0.3.31", default-features = false }
 comma_serde_urlencoded = "0.8.1"
 
 [dev-dependencies]
-tokio = { version = "1.42.0", features = ["macros"] }
+tokio = { version = "1.45.1", features = ["macros"] }
 
 [features]
 default = ["bot"]

--- a/src/api/board.rs
+++ b/src/api/board.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use crate::{
     client::{Licheszter, UrlBase},
     config::board::SeekOptions,
@@ -16,7 +18,7 @@ impl Licheszter {
     pub async fn board_seek_create(
         &self,
         options: Option<&SeekOptions>,
-    ) -> Result<impl Stream<Item = Result<()>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<()>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, "api/board/seek");
         let mut builder = self.client.post(url);
 
@@ -35,7 +37,7 @@ impl Licheszter {
     pub async fn board_game_connect(
         &self,
         game_id: &str,
-    ) -> Result<impl Stream<Item = Result<BoardState>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<BoardState>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, &format!("api/board/game/stream/{game_id}"));
         let builder = self.client.get(url);
 

--- a/src/api/bot.rs
+++ b/src/api/bot.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use crate::{
     client::{Licheszter, UrlBase},
     error::Result,
@@ -14,7 +16,7 @@ impl Licheszter {
     pub async fn bot_game_connect(
         &self,
         game_id: &str,
-    ) -> Result<impl Stream<Item = Result<BoardState>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<BoardState>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, &format!("api/bot/game/stream/{game_id}"));
         let builder = self.client.get(url);
 

--- a/src/api/challenges.rs
+++ b/src/api/challenges.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use futures_util::Stream;
 use reqwest::header;
 
@@ -53,7 +55,7 @@ impl Licheszter {
         &self,
         username: &str,
         options: Option<&ChallengeOptions>,
-    ) -> Result<impl Stream<Item = Result<ChallengeComplete>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<ChallengeComplete>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, &format!("api/challenge/{username}"));
         let mut builder = self.client.post(url).form(&[("keepAliveStream", true)]);
 

--- a/src/api/misc.rs
+++ b/src/api/misc.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use crate::{
     client::{Licheszter, UrlBase},
     error::Result,
@@ -13,7 +15,7 @@ use futures_util::Stream;
 impl Licheszter {
     /// Stream the events reaching a Lichess user in real time.
     /// When the stream opens, all current challenges and games are sent.
-    pub async fn connect(&self) -> Result<impl Stream<Item = Result<Event>>> {
+    pub async fn connect(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Event>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, "api/stream/event");
         let builder = self.client.get(url);
 
@@ -31,7 +33,10 @@ impl Licheszter {
     }
 
     /// Get online bots.
-    pub async fn bots_online(&self, bots: u8) -> Result<impl Stream<Item = Result<BasicUser>>> {
+    pub async fn bots_online(
+        &self,
+        bots: u8,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<BasicUser>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, "api/bot/online");
         let builder = self.client.get(url).query(&[("nb", bots)]);
 

--- a/src/api/openings.rs
+++ b/src/api/openings.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use crate::{
     client::{Licheszter, UrlBase},
     config::openings::{LichessOpeningsOptions, MastersOpeningsOptions, PlayerOpeningsOptions},
@@ -44,7 +46,7 @@ impl Licheszter {
         player: &str,
         color: Color,
         options: Option<&PlayerOpeningsOptions>,
-    ) -> Result<impl Stream<Item = Result<PlayerOpening>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<PlayerOpening>> + Send>>> {
         let mut url = self.req_url(UrlBase::Openings, "player");
         let encoded = comma_serde_urlencoded::to_string((("player", player), ("color", color)))?;
         url.set_query(Some(&encoded));

--- a/src/api/puzzles.rs
+++ b/src/api/puzzles.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use futures_util::Stream;
 
 use crate::{
@@ -45,7 +47,7 @@ impl Licheszter {
         &self,
         max: Option<u16>,
         before: Option<u64>,
-    ) -> Result<impl Stream<Item = Result<PuzzleActivity>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<PuzzleActivity>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, "api/puzzle/activity");
         let builder = self.client.get(url).query(&(("max", max), ("before", before)));
 

--- a/src/api/relations.rs
+++ b/src/api/relations.rs
@@ -1,3 +1,5 @@
+use std::pin::Pin;
+
 use futures_util::Stream;
 
 use crate::{
@@ -8,7 +10,9 @@ use crate::{
 
 impl Licheszter {
     /// Get a list of users followed by the logged in user.
-    pub async fn relations_followed_users_list(&self) -> Result<impl Stream<Item = Result<User>>> {
+    pub async fn relations_followed_users_list(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<User>> + Send>>> {
         let url = self.req_url(UrlBase::Lichess, "api/rel/following");
         let builder = self.client.get(url);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -131,7 +131,9 @@ impl Licheszter {
     pub(crate) fn req_url(&self, url: UrlBase, path: &str) -> Url {
         let mut base = match url {
             UrlBase::Lichess => self.base_url.clone(),
+            #[cfg(feature = "openings")]
             UrlBase::Openings => self.openings_url.clone(),
+            #[cfg(feature = "tablebase")]
             UrlBase::Tablebase => self.tablebase_url.clone(),
         };
         base.set_path(path);
@@ -258,6 +260,8 @@ impl Default for LicheszterBuilder {
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum UrlBase {
     Lichess,
+    #[cfg(feature = "openings")]
     Openings,
+    #[cfg(feature = "tablebase")]
     Tablebase,
 }

--- a/tests/openings.rs
+++ b/tests/openings.rs
@@ -14,7 +14,7 @@ use licheszter::{
 use tokio::time::{sleep, Duration};
 
 // Connect to a test client
-static EXPLORER: LazyLock<Licheszter> = LazyLock::new(|| Licheszter::new());
+static EXPLORER: LazyLock<Licheszter> = LazyLock::new(Licheszter::new);
 
 #[tokio::test]
 async fn openings_masters() {

--- a/tests/tablebase.rs
+++ b/tests/tablebase.rs
@@ -5,7 +5,7 @@ use std::{error::Error, sync::LazyLock};
 use licheszter::client::Licheszter;
 
 // Connect to a test client
-static TABLEBASE: LazyLock<Licheszter> = LazyLock::new(|| Licheszter::new());
+static TABLEBASE: LazyLock<Licheszter> = LazyLock::new(Licheszter::new);
 
 #[tokio::test]
 async fn tablebase_standard() {


### PR DESCRIPTION
Upgrades Rust to 2024 edition and fixes a long-time issue related to compiling without `--all-features` flag.